### PR TITLE
Allow usage of Ansible module group defaults (add meta/runtime.yml)

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,19 @@
+---
+requires_ansible: ">=2.9.10"
+action_groups:
+  netapp_storagegrid:
+    - na_sg_grid_account
+    - na_sg_grid_certificate
+    - na_sg_grid_dns
+    - na_sg_grid_group
+    - na_sg_grid_identity_federation
+    - na_sg_grid_info
+    - na_sg_grid_ntp
+    - na_sg_grid_regions
+    - na_sg_grid_user
+    - na_sg_org_container
+    - na_sg_org_group
+    - na_sg_org_identity_federation
+    - na_sg_org_info
+    - na_sg_org_user
+    - na_sg_org_user_s3_key


### PR DESCRIPTION
##### SUMMARY
Allow usage of Ansible module group defaults

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html

##### ADDITIONAL INFORMATION
Allows usage of module defaults like:
```
- hosts: localhost
  connection: local
  gather_facts: false
  collections:
    - netapp.storagegrid
  module_defaults:
    group/netapp.ontap.netapp_storagegrid:
       # common options goes here
```