### PR TITLE
fixed issue when org user is not updated when group membership changes

### DIFF
--- a/plugins/modules/na_sg_org_user.py
+++ b/plugins/modules/na_sg_org_user.py
@@ -258,17 +258,14 @@ class SgOrgUser(object):
             # let's see if we need to update parameters
             update = False
 
-            if org_user["memberOf"] is None:
-                member_of_diff = []
-            else:
-                member_of_diff = [
-                    i
-                    for i in self.data["memberOf"] + org_user["memberOf"]
-                    if i not in self.data["memberOf"] or i not in org_user["memberOf"]
-                ]
-            if member_of_diff:
+            # Compare current and desired group memberships
+            current_groups = set(org_user["memberOf"] or [])
+            desired_groups = set(self.data["memberOf"] or [])
+
+            if current_groups != desired_groups:
                 update = True
 
+            # Check if disable state needs to be updated
             if self.parameters.get("disable") is not None and self.parameters["disable"] != org_user.get("disable"):
                 update = True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
User will not be update with group membership if already exists.
Changed the method how group members gets compared
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module na_sg_org_user
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
